### PR TITLE
refactored modern_convnet.py code for r11

### DIFF
--- a/python/libs/batch_norm.py
+++ b/python/libs/batch_norm.py
@@ -3,7 +3,6 @@ Parag K. Mital, Jan 2016.
 """
 
 import tensorflow as tf
-from tensorflow.python import control_flow_ops
 
 
 def batch_norm(x, phase_train, scope='bn', affine=True):
@@ -54,7 +53,7 @@ def batch_norm(x, phase_train, scope='bn', affine=True):
             """
             with tf.control_dependencies([ema_apply_op]):
                 return tf.identity(batch_mean), tf.identity(batch_var)
-        mean, var = control_flow_ops.cond(phase_train,
+        mean, var = tf.cond(phase_train,
                                           mean_var_with_update,
                                           lambda: (ema_mean, ema_var))
 

--- a/python/libs/connections.py
+++ b/python/libs/connections.py
@@ -3,7 +3,6 @@ from Parag K. Mital.
 """
 import math
 import tensorflow as tf
-from tensorflow.python import control_flow_ops
 
 
 def batch_norm(x, phase_train, scope='bn', affine=True):
@@ -51,7 +50,7 @@ def batch_norm(x, phase_train, scope='bn', affine=True):
             """
             with tf.control_dependencies([ema_apply_op]):
                 return tf.identity(batch_mean), tf.identity(batch_var)
-        mean, var = control_flow_ops.cond(phase_train,
+        mean, var = tf.cond(phase_train,
                                           mean_var_with_update,
                                           lambda: (ema_mean, ema_var))
 


### PR DESCRIPTION
modern_convnet.py   uses deprecated 

`control_flow_ops` 

it look like the functions have been recently moved up to the tf level
