### PR TITLE
Update to batch_norm (Unwanted ema updates)

### DIFF
--- a/python/libs/batch_norm.py
+++ b/python/libs/batch_norm.py
@@ -41,7 +41,6 @@ def batch_norm(x, phase_train, scope='bn', affine=True):
 
         batch_mean, batch_var = tf.nn.moments(x, [0, 1, 2], name='moments')
         ema = tf.train.ExponentialMovingAverage(decay=0.9)
-        ema_apply_op = ema.apply([batch_mean, batch_var])
         ema_mean, ema_var = ema.average(batch_mean), ema.average(batch_var)
 
         def mean_var_with_update():
@@ -52,6 +51,7 @@ def batch_norm(x, phase_train, scope='bn', affine=True):
             name : TYPE
                 Description
             """
+            ema_apply_op = ema.apply([batch_mean, batch_var])
             with tf.control_dependencies([ema_apply_op]):
                 return tf.identity(batch_mean), tf.identity(batch_var)
         mean, var = control_flow_ops.cond(phase_train,


### PR DESCRIPTION
Fixed problem that causes an update to the exponential moving average of the mean and variance even while phase_train is False. 

You also want to consider using "tf.cond" over "control_flow_ops.cond", and removing the control_flow_ops import (This will break if using a more recent TensorFlow version).