### PR TITLE
Fix misleading documentation in montage functions

### DIFF
--- a/python/libs/utils.py
+++ b/python/libs/utils.py
@@ -12,8 +12,8 @@ def montage_batch(images):
 
     Parameters
     ----------
-    batch : Tensor
-        Input tensor to create montage of.
+    batch : numpy.ndarray
+        Input array to create montage of.
 
     Returns
     -------
@@ -44,8 +44,8 @@ def montage(W):
 
     Parameters
     ----------
-    W : Tensor
-        Input tensor to create montage of.
+    W : numpy.ndarray
+        Input array to create montage of.
 
     Returns
     -------


### PR DESCRIPTION
The documentation on [`utils.montage`](https://github.com/pkmital/tensorflow_tutorials/blob/master/python/libs/utils.py#L47) and `utils.montage_batch` suggests that these functions work with tensors as input. However, they actually receive a numpy array. For handling tensors as inputs and outputs (e.g. when creating TF summaries), it would have to be wrapped around `tf.py_func`. Here's a PR to fix the documentation.

Thank you for this tutorial, it was a helpful resource.