### PR TITLE
Update 01_basic.py

### DIFF
--- a/python/01_basics.py
+++ b/python/01_basics.py
@@ -36,7 +36,7 @@ x.eval()
 # We'll use our values from [-3, 3] to create a Gaussian Distribution
 sigma = 1.0
 mean = 0.0
-z = (tf.exp(tf.neg(tf.pow(x - mean, 2.0) /
+z = (tf.exp(tf.negative(tf.pow(x - mean, 2.0) /
                    (2.0 * tf.pow(sigma, 2.0)))) *
      (1.0 / (sigma * tf.sqrt(2.0 * 3.1415))))
 


### PR DESCRIPTION
Since Tensorflow 1.0.0, `tf.neg` is deprecated in favor of `tf.negative`, see https://www.tensorflow.org/api_docs/python/tf/negative  and https://github.com/tensorflow/tensorflow/releases